### PR TITLE
Fix for handling input with only one line.

### DIFF
--- a/jupynotex.py
+++ b/jupynotex.py
@@ -192,6 +192,11 @@ class Notebook:
         """Process the source of a cell."""
         source = content['source']
         result = []
+
+        # Ensure `source` is a list of strings
+        if isinstance(source, str):
+            source = [source]  # Convert single string to a list
+
         if content['cell_type'] == 'code':
             begin, end = self._highlight_delimiters
             result.extend(begin)


### PR DESCRIPTION
This is a fix for the previously open issue : https://github.com/facundobatista/jupynotex/issues/16
Adding the handling of the case where a cell only contain one line of code, in that case convert it in a list before processing it.